### PR TITLE
Standardize Log parameter names and output format

### DIFF
--- a/docs/Log/LogAPI.md
+++ b/docs/Log/LogAPI.md
@@ -82,7 +82,7 @@ formatting.
 
 ```c
 lgLog("Smile version %.1f is out!", 1.0f);
-// Outputs: 01:23:45 [Smile Log From User] - Smile version 1.0 is out!
+// Outputs: 01:23:45 [User LOG] - Smile version 1.0 is out!
 
 const char *untrustedInput = getExternalText();
 lgLog("%s", untrustedInput); // Safe for arbitrary text input

--- a/docs/Log/README.md
+++ b/docs/Log/README.md
@@ -81,7 +81,7 @@ void MyFatalHandler(void)
 int main()
 {
     lgLog("Smile version %.1f is out!", 1.0f);
-    // Outputs: 01:23:45 [Smile Log From User] - Smile version 1.0 is out!
+    // Outputs: 01:23:45 [User LOG] - Smile version 1.0 is out!
 
     lgSetFatal(MyFatalHandler); // Set a custom fatal handler
     

--- a/docs/internal/LogInternalAPI.md
+++ b/docs/internal/LogInternalAPI.md
@@ -70,19 +70,20 @@ lgInternalLog(ERROR, ORI, CSE_NOT_RUNNING, fnName, CSQ_ABORT);
 
 ### — Log Related
 
-| `int lgInternalLog(lgInternalLevel level, const char *module, const char *cause, const char *fnName, const char *conseq)` |
-|---------------------------------------------------------------------------------------------------------------------------|
+| `int lgInternalLog(lgInternalLevel lvl, const char *ori, const char *cse, const char *caller, const char *csq)` |
+|-----------------------------------------------------------------------------------------------------------------|
 
 Used by Smile modules to log info, warnings, errors, or fatal events.
 
-Provides module name, cause, function name, and consequences for context.
+Provides module name, cause, caller identifier, and consequences for context.
 
 - Parameters:
-    - `level` — Severity level of the log (`INFO`, `WARN`, etc.).
-    - `module` — Name of the module generating the log.
-    - `cause` — Description of the cause of the log event.
-    - `fnName` — Name of the function where the log is generated.
-    - `conseq` — Consequences or additional information about the event.
+    - `lvl` — Severity level of the log (`INFO`, `WARN`, etc.).
+    - `ori` — Name of the module or tool generating the log.
+    - `cse` — Description of the cause of the log event.
+    - `caller` — Identifier of the caller — typically the function name (e.g.
+      `__func__`), or the tool name for top-level tool logs.
+    - `csq` — Consequences or additional information about the event.
 
 - Returns: `0` on success, or a negative result code on failure.
 
@@ -90,7 +91,7 @@ Provides module name, cause, function name, and consequences for context.
     - Common failures use `cmResult` (for example, `RES_NULL_ARG`).
     - Log-specific failures use `lgInternalResult`:
       `RES_TIME_FAIL`, `RES_WRITE_FAIL`.
-    - If `level` is `FATAL`, the configured fatal handler is invoked after
+    - If `lvl` is `FATAL`, the configured fatal handler is invoked after
       attempting to log.
 
 ✅ Example
@@ -110,8 +111,8 @@ bool smPrivateHasStarted(const char *fnName)
 
 <br>
 
-| `int lgInternalLogWithArg(lgInternalLevel level, const char *module, const char *cause, const char *arg, const char *fnName, const char *conseq)` |
-|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `int lgInternalLogWithArg(lgInternalLevel lvl, const char *ori, const char *cse, const char *arg, const char *caller, const char *csq)` |
+|-----------------------------------------------------------------------------------------------------------------------------------------|
 
 Used by Smile modules to log info, warnings, errors, or fatal events with
 additional context.
@@ -120,12 +121,13 @@ Similar to lgInternalLog, but includes an extra argument string for additional
 context.
 
 - Parameters:
-    - `level` — Severity level of the log (`INFO`, `WARN`, etc.).
-    - `module` — Name of the module generating the log.
-    - `cause` — Description of the cause of the log event.
+    - `lvl` — Severity level of the log (`INFO`, `WARN`, etc.).
+    - `ori` — Name of the module or tool generating the log.
+    - `cse` — Description of the cause of the log event.
     - `arg` — Additional context argument relevant to the log event.
-    - `fnName` — Name of the function where the log is generated.
-    - `conseq` — Consequences or additional information about the event.
+    - `caller` — Identifier of the caller — typically the function name (e.g.
+      `__func__`), or the tool name for top-level tool logs.
+    - `csq` — Consequences or additional information about the event.
 
 - Returns: `0` on success, or a negative result code on failure.
 
@@ -133,7 +135,7 @@ context.
     - Common failures use `cmResult` (for example, `RES_NULL_ARG`).
     - Log-specific failures use `lgInternalResult`:
       `RES_TIME_FAIL`, `RES_WRITE_FAIL`.
-    - If `level` is `FATAL`, the configured fatal handler is invoked after
+    - If `lvl` is `FATAL`, the configured fatal handler is invoked after
       attempting to log.
 
 ✅ Example

--- a/src/Log/Log.c
+++ b/src/Log/Log.c
@@ -38,50 +38,50 @@
  *
  * Wraps variable argument handling for internal logging functions.
  *
- * @param level Severity level of the log message.
+ * @param lvl Severity level of the log message.
  * @param origin Origin or module name for the log message.
  * @param msg Format string for the message to log.
  * @param ... Additional arguments for the format string.
  *
  * @author Vitor Betmann
  */
-static int lgPrivateLog(lgInternalLevel level, const char *origin, const char *msg, ...);
+static int lgPrivateLog(lgInternalLevel lvl, const char *origin, const char *msg, ...);
 
 /**
  * @brief Outputs formatted messages.
  *
- * Handles timestamp formatting, color coding, log prefixes, and log level
- * filtering.
+ * Handles timestamp formatting, color coding, log prefixes, and log level filtering.
  *
- * @param level Severity level of the log message.
- * @param origin Origin or module name for the log message.
+ * @param lvl Severity level of the log message.
+ * @param ori Origin or module name for the log message.
  * @param msg Format string for the message to log.
  * @param args Variable argument list corresponding to the format string.
  *
  * @author Vitor Betmann
  */
-static int lgPrivateLogV(lgInternalLevel level, const char *origin, const char *msg, va_list args);
+static int lgPrivateLogV(lgInternalLevel lvl, const char *ori, const char *msg, va_list args);
 
 /**
  * @brief Determines if logging is enabled for a given level.
  *
- * @param level Severity level to check.
+ * @param lvl Severity level to check.
  * @return true if logging is enabled for the level, false otherwise.
  *
  * @author Vitor Betmann
  */
-static bool lgPrivateIsLevelEnabled(lgInternalLevel level);
+static bool lgPrivateIsLevelEnabled(lgInternalLevel lvl);
 
 /**
  * @brief Determines the color and prefix for a given log level.
  *
- * @param level Severity level of the log message.
+ * @param lvl Severity level of the log message.
  * @param color Output pointer to the ANSI color string for the level.
  * @param prefix Output pointer to the prefix string for the level.
  *
  * @author Vitor Betmann
  */
-static void lgPrivateGetColorAndPrefix(lgInternalLevel level, const char **color, const char **prefix);
+static void lgPrivateGetColorAndPrefix(lgInternalLevel lvl, const char **color,
+                                       const char **prefix);
 
 /**
  * @brief Default handler for fatal log events.
@@ -132,51 +132,51 @@ int lgSetFatal(lgFatalHandler handler)
 // Functions - Internal
 // —————————————————————————————————————————————————————————————————————————————————————————————————
 
-int lgInternalLog(lgInternalLevel level, const char *origin, const char *cse, const char *fnName, const char *csq)
+int lgInternalLog(lgInternalLevel lvl, const char *ori, const char *cse, const char *caller,
+                  const char *csq)
 {
-    if (!origin || !cse || !fnName || !csq)
+    if (!ori || !cse || !caller || !csq)
     {
         return RES_NULL_ARG;
     }
 
-    return lgPrivateLog(level, origin, "%s. '%s' %s.", cse, fnName, csq);
+    return lgPrivateLog(lvl, ori, "%s. '%s' %s.", cse, caller, csq);
 }
 
-int lgInternalLogWithArg(lgInternalLevel lvl, const char *origin, const char *cause, const char *arg,
-                         const char *fnName, const char *csq)
+int lgInternalLogWithArg(lgInternalLevel lvl, const char *ori, const char *cause, const char *arg,
+                         const char *caller, const char *csq)
 {
-    if (!origin || !cause || !arg || !fnName || !csq)
+    if (!ori || !cause || !arg || !caller || !csq)
     {
         return RES_NULL_ARG;
     }
 
-    return lgPrivateLog(lvl, origin, "%s: %s. '%s' %s.", cause, arg, fnName,
-                        csq);
+    return lgPrivateLog(lvl, ori, "%s: %s. '%s' %s.", cause, arg, caller, csq);
 }
 
 // —————————————————————————————————————————————————————————————————————————————————————————————————
 // Functions - Private
 // —————————————————————————————————————————————————————————————————————————————————————————————————
 
-static int lgPrivateLog(lgInternalLevel level, const char *origin, const char *msg, ...)
+static int lgPrivateLog(lgInternalLevel lvl, const char *origin, const char *msg, ...)
 {
     va_list args;
     va_start(args, msg);
-    int result = lgPrivateLogV(level, origin, msg, args);
+    int result = lgPrivateLogV(lvl, origin, msg, args);
     va_end(args);
     return result;
 }
 
-static int lgPrivateLogV(lgInternalLevel level, const char *origin, const char *msg, va_list args)
+static int lgPrivateLogV(lgInternalLevel lvl, const char *ori, const char *msg, va_list args)
 {
-    if (!lgPrivateIsLevelEnabled(level))
+    if (!lgPrivateIsLevelEnabled(lvl))
     {
         return RES_OK;
     }
 
     const char *color = nullptr;
     const char *prefix = nullptr;
-    lgPrivateGetColorAndPrefix(level, &color, &prefix);
+    lgPrivateGetColorAndPrefix(lvl, &color, &prefix);
 
     char timeBuf[LOG_TIME_BUFFER_LEN] = "00:00:00";
     const time_t epochTime = time(nullptr);
@@ -193,7 +193,7 @@ static int lgPrivateLogV(lgInternalLevel level, const char *origin, const char *
     }
     if (!hasLocalTime)
     {
-        if (level == FATAL)
+        if (lvl == FATAL)
         {
             fatalHandler();
         }
@@ -202,18 +202,18 @@ static int lgPrivateLogV(lgInternalLevel level, const char *origin, const char *
 
     if (strftime(timeBuf, sizeof(timeBuf), LOG_TIME_FMT, &localTime) == 0)
     {
-        if (level == FATAL)
+        if (lvl == FATAL)
         {
             fatalHandler();
         }
         return RES_TIME_FAIL;
     }
 
-    int prefixStatus = fprintf(stderr, "%s%s [Smile %s From %s] - ", color, timeBuf, prefix, origin);
+    int prefixStatus = fprintf(stderr, "%s%s [%s %s] - ", color, timeBuf, ori, prefix);
     int messageStatus = vfprintf(stderr, msg, args);
-    int suffixStatus = fprintf(stderr, "%s\n", SMILE_WHITE); // Reset colour
+    int suffixStatus = fprintf(stderr, "%s\n", SMILE_WHITE); // Reset color
     int flushStatus = 0;
-    if (level == ERROR || level == FATAL)
+    if (lvl == ERROR || lvl == FATAL)
     {
         flushStatus = fflush(stderr);
     }
@@ -221,23 +221,23 @@ static int lgPrivateLogV(lgInternalLevel level, const char *origin, const char *
     if (prefixStatus < 0 || messageStatus < 0 || suffixStatus < 0 ||
         flushStatus == EOF)
     {
-        if (level == FATAL)
+        if (lvl == FATAL)
         {
             fatalHandler();
         }
         return RES_WRITE_FAIL;
     }
 
-    if (level == FATAL)
+    if (lvl == FATAL)
     {
         fatalHandler();
     }
     return RES_OK;
 }
 
-static bool lgPrivateIsLevelEnabled(lgInternalLevel level)
+static bool lgPrivateIsLevelEnabled(lgInternalLevel lvl)
 {
-    switch (level)
+    switch (lvl)
     {
     case INFO:
 #ifdef SMILE_INFO
@@ -256,29 +256,30 @@ static bool lgPrivateIsLevelEnabled(lgInternalLevel level)
     }
 }
 
-static void lgPrivateGetColorAndPrefix(lgInternalLevel level, const char **color, const char **prefix)
+static void lgPrivateGetColorAndPrefix(lgInternalLevel lvl, const char **color,
+                                       const char **prefix)
 {
-    switch (level)
+    switch (lvl)
     {
     case USER:
         *color = SMILE_GREEN;
-        *prefix = "Log";
+        *prefix = "LOG";
         return;
     case INFO:
         *color = SMILE_CYAN;
-        *prefix = "Info";
+        *prefix = "INFO";
         return;
     case WARN:
         *color = SMILE_YELLOW;
-        *prefix = "Warning";
+        *prefix = "WARNING";
         return;
     case ERROR:
         *color = SMILE_RED;
-        *prefix = "Error";
+        *prefix = "ERROR";
         return;
     case FATAL:
         *color = SMILE_PURPLE;
-        *prefix = "Fatal";
+        *prefix = "FATAL";
         return;
     default:
         *color = SMILE_WHITE;

--- a/src/Log/LogInternal.h
+++ b/src/Log/LogInternal.h
@@ -73,10 +73,10 @@ typedef enum
  *
  * Provides module or tool name, cause, function name, and consequences for context.
  *
- * @param level Severity level of the log (INFO, WARN, etc.).
- * @param origin Name of the module or tool generating the log.
+ * @param lvl Severity level of the log (INFO, WARN, etc.).
+ * @param ori Name of the module or tool generating the log.
  * @param cse Description of the cause of the log event.
- * @param fnName Name of the function where the log is generated.
+ * @param caller Name of the function where the log is generated.
  * @param csq Consequences or additional information about the event.
  *
  * @return Returns `0` on success, or a negative error code on failure.
@@ -89,7 +89,8 @@ typedef enum
  *
  * @author Vitor Betmann
  */
-int lgInternalLog(lgInternalLevel level, const char *origin, const char *cse, const char *fnName, const char *csq);
+int lgInternalLog(lgInternalLevel lvl, const char *ori, const char *cse, const char *caller,
+                  const char *csq);
 
 /**
  * @brief Used by Smile modules to log info, warnings, errors, or fatal events
@@ -99,10 +100,10 @@ int lgInternalLog(lgInternalLevel level, const char *origin, const char *cse, co
  * additional context.
  *
  * @param lvl Severity level of the log (WARN, ERROR, etc.).
- * @param origin Name of the module generating the log.
- * @param cause Description of the cause of the log event.
+ * @param ori Name of the module or tool generating the log.
+ * @param cse Description of the cause of the log event.
  * @param arg Additional context argument relevant to the log event.
- * @param fnName Name of the function where the log is generated.
+ * @param caller Name of the function where the log is generated.
  * @param csq Consequences or additional information about the event.
  *
  * @return Returns `0` on success, or a negative error code on failure.
@@ -115,8 +116,8 @@ int lgInternalLog(lgInternalLevel level, const char *origin, const char *cse, co
  *
  * @author Vitor Betmann
  */
-int lgInternalLogWithArg(lgInternalLevel lvl, const char *origin, const char *cse, const char *arg, const char *fnName,
-                         const char *csq);
+int lgInternalLogWithArg(lgInternalLevel lvl, const char *ori, const char *cse, const char *arg,
+                         const char *caller, const char *csq);
 
 
 #endif


### PR DESCRIPTION
Rename parameters across Log.c, LogInternal.h, and LogInternalAPI.md: level → lvl, origin/module → ori, fnName → caller, conseq → Change log output from "[Smile <PREFIX> From <ORI>]" to "[<ORI> <PREFIX>]" and uppercase all level prefix strings (Log → LOG, Warning → WARNING, etc.).

Update LogInternalAPI.md to broaden the caller description — it accepts either __func__ (modules) or the tool name (tools where main is the only entry point, e.g. GenScene). 