### PR TITLE
Add angular velocity and improve lifetime defaults for ParticleSystem

### DIFF
--- a/docs/ParticleSystem/ParticleSystemAPI.md
+++ b/docs/ParticleSystem/ParticleSystemAPI.md
@@ -52,7 +52,9 @@ Represents a single active particle in the system.
     - `float velocityX, velocityY` — Current velocity components.
     - `float accelerationX, accelerationY` — Current acceleration components.
     - `float age` — Time elapsed since emission, in seconds.
-    - `float lifetime` — Total lifespan of the particle, in seconds.
+    - `float lifetime` — Total lifespan of the particle, in seconds. Pass `INFINITY` for a particle that never expires.
+    - `float angle` — Current rotation angle, in radians. Starts at `0` on emission.
+    - `float angularVelocity` — Rotation speed, in radians per second.
 
 - Notes:
     - Passed as `const Particle *` to `ParticleFn` and as the snapshot array
@@ -635,12 +637,49 @@ Sets the random lifetime range assigned to each newly emitted particle.
     - Fails if `ps` is `nullptr` or `min > max`.
     - Each emitted particle receives a lifetime sampled uniformly at random
       from `[min, max]`.
+    - Pass `INFINITY` for both `min` and `max` to emit particles that never
+      expire. Use `psReset()` to remove them.
+    - Defaults to `1.0f` for both `min` and `max` if never called.
 
 ✅ Example
 
 ```c
 // Particles live between half a second and two seconds.
 psSetLifetime(ps, 0.5f, 2.0f);
+
+// Immortal particles — only removed by psReset() or psDestroy().
+psSetLifetime(ps, INFINITY, INFINITY);
+```
+
+<br>
+
+| `int psSetAngularVelocity(ParticleSystem *ps, float min, float max)` |
+|----------------------------------------------------------------------|
+
+Sets the random angular velocity range assigned to each newly emitted particle.
+
+- Parameters:
+    - `ps` — ParticleSystem to configure.
+    - `min` — Minimum angular velocity in radians per second.
+    - `max` — Maximum angular velocity in radians per second.
+
+- Returns: `0` on success, or a negative result code on failure.
+
+- Notes:
+    - Fails if `ps` is `nullptr` or `min > max`.
+    - Each emitted particle receives an angular velocity sampled uniformly at
+      random from `[min, max]`. Its `angle` field is initialized to `0` on
+      emission and advances by `angularVelocity * dt` each update.
+    - Defaults to `0.0f` for both `min` and `max` (no rotation).
+    - Negative values produce counter-clockwise rotation; positive values
+      produce clockwise rotation (or vice versa, depending on your coordinate
+      system).
+
+✅ Example
+
+```c
+// Spin each particle between half and two full rotations per second.
+psSetAngularVelocity(ps, 3.14f, 12.57f);
 ```
 
 <br>

--- a/docs/ParticleSystem/README.md
+++ b/docs/ParticleSystem/README.md
@@ -82,7 +82,7 @@ frees all memory and invalidates the pointer.
 
 | Signature    | Description                                                  |
 |--------------|--------------------------------------------------------------|
-| `Particle`   | Represents a single active particle with position, velocity, acceleration, age, and lifetime. |
+| `Particle`   | Represents a single active particle with position, velocity, acceleration, age, lifetime, angle, and angular velocity. |
 
 — Enums
 
@@ -106,7 +106,7 @@ frees all memory and invalidates the pointer.
 |----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | `ParticleSystem *psCreate(int maxParticles, float originX, float originY)`                                     | Allocates and initializes a new ParticleSystem.                               |
 | `int psDestroy(ParticleSystem *ps)`                                                                            | Frees all memory associated with the ParticleSystem.                          |
-| `int psReset(ParticleSystem *ps)`                                                                              | Deactivates all particles and resets streaming state without freeing.         |
+| `int psReset(ParticleSystem *ps)`                                                                              | Deactivates all particles without freeing the instance or clearing configuration. |
 | `int psBurst(ParticleSystem *ps, int amount)`                                                                  | Emits a fixed number of particles immediately.                                |
 | `int psStream(ParticleSystem *ps, float rate)`                                                                 | Sets the continuous emission rate in particles per second.                    |
 | `int psUpdate(ParticleSystem *ps, float dt)`                                                                   | Advances the simulation by dt seconds.                                        |
@@ -119,7 +119,8 @@ frees all memory and invalidates the pointer.
 | `int psSetSpread(ParticleSystem *ps, float innerX, float innerY, float outerX, float outerY)`                  | Configures the inner and outer emission spread around the origin.             |
 | `int psSetVelocity(ParticleSystem *ps, float minX, float minY, float maxX, float maxY)`                        | Sets the random velocity range assigned to each newly emitted particle.       |
 | `int psSetAcceleration(ParticleSystem *ps, float minX, float minY, float maxX, float maxY)`                    | Sets the random acceleration range assigned to each newly emitted particle.   |
-| `int psSetLifetime(ParticleSystem *ps, float min, float max)`                                                  | Sets the random lifetime range assigned to each newly emitted particle.       |
+| `int psSetLifetime(ParticleSystem *ps, float min, float max)`                                                  | Sets the random lifetime range assigned to each newly emitted particle. Pass `INFINITY` for immortal particles. Defaults to `1.0f`. |
+| `int psSetAngularVelocity(ParticleSystem *ps, float min, float max)`                                           | Sets the random angular velocity range (radians/sec) assigned to each newly emitted particle. Defaults to `0.0f`. |
 | `int psSetEmissionShape(ParticleSystem *ps, psEmissionShape shape)`                                            | Sets the geometric shape used to sample particle spawn positions.             |
 | `int psSetInfluence(ParticleSystem *ps, void *context, InfluenceFn fn)`                                        | Registers a per-particle callback applied each update.                        |
 | `int psSetSnapshotInfluence(ParticleSystem *ps, void *context, SnapshotInfluenceFn fn)`                        | Registers a snapshot-based influence callback applied each update.            |

--- a/include/ParticleSystem.h
+++ b/include/ParticleSystem.h
@@ -9,7 +9,9 @@ typedef struct
     float velocityX, velocityY;         /**< Current velocity components. */
     float accelerationX, accelerationY; /**< Current acceleration components. */
     float age;                          /**< Time elapsed since emission, in seconds. */
-    float lifetime;                     /**< Total lifespan of the particle, in seconds. */
+    float lifetime;                     /**< Total lifespan of the particle, in seconds. Pass INFINITY for an immortal particle. */
+    float angle;                        /**< Current rotation angle, in radians. */
+    float angularVelocity;              /**< Rotation speed, in radians per second. */
 } Particle;
 
 /**
@@ -224,6 +226,17 @@ int psSetAcceleration(ParticleSystem *ps, float minX, float minY, float maxX, fl
  * @return 0 on success, or a negative result code on failure.
  */
 int psSetLifetime(ParticleSystem *ps, float min, float max);
+
+/**
+ * @brief Sets the random angular velocity range assigned to each newly emitted particle.
+ *
+ * @param ps  ParticleSystem to configure.
+ * @param min Minimum angular velocity in radians per second.
+ * @param max Maximum angular velocity in radians per second.
+ *
+ * @return 0 on success, or a negative result code on failure.
+ */
+int psSetAngularVelocity(ParticleSystem *ps, float min, float max);
 
 // -- Shape
 

--- a/src/ParticleSystem/ParticleSystem.c
+++ b/src/ParticleSystem/ParticleSystem.c
@@ -50,6 +50,8 @@ ParticleSystem *psCreate(int maxParticles, float originX, float originY)
     ps->maxParticles = maxParticles;
     ps->originX = originX;
     ps->originY = originY;
+    ps->minLifetime = 1.0f;
+    ps->maxLifetime = 1.0f;
 
     if (!isSeedSet)
     {
@@ -123,6 +125,11 @@ int psBurst(ParticleSystem *ps, int amount)
         const float lifetimeDiff = ps->maxLifetime - ps->minLifetime;
         p->lifetime = ps->minLifetime + (float)rand() / (float)RAND_MAX * lifetimeDiff;
         p->age = 0.0f;
+        // Angular velocity
+        const float angularVelocityDiff = ps->maxAngularVelocity - ps->minAngularVelocity;
+        p->angularVelocity =
+            ps->minAngularVelocity + (float)rand() / (float)RAND_MAX * angularVelocityDiff;
+        p->angle = 0.0f;
     }
 
     return RES_OK;
@@ -176,6 +183,7 @@ int psUpdate(ParticleSystem *ps, float dt)
         p->velocityY += p->accelerationY * dt;
         p->x += p->velocityX * dt;
         p->y += p->velocityY * dt;
+        p->angle += p->angularVelocity * dt;
 
         if (p->age >= p->lifetime)
         {
@@ -379,6 +387,26 @@ int psSetLifetime(ParticleSystem *ps, float min, float max)
 
     ps->minLifetime = min;
     ps->maxLifetime = max;
+
+    return RES_OK;
+}
+
+int psSetAngularVelocity(ParticleSystem *ps, float min, float max)
+{
+    if (psPrivateIsPsNull(ps, __func__))
+    {
+        return RES_NULL_ARG;
+    }
+
+    if (min > max)
+    {
+        lgInternalLogWithArg(WARN, ORI, CSE_INVALID_ARG, MSG_INVALID_ANGULAR_VELOCITY_RANGE,
+                             __func__, CSQ_ABORT);
+        return RES_INVALID_ARG;
+    }
+
+    ps->minAngularVelocity = min;
+    ps->maxAngularVelocity = max;
 
     return RES_OK;
 }

--- a/src/ParticleSystem/ParticleSystemInternal.h
+++ b/src/ParticleSystem/ParticleSystemInternal.h
@@ -38,6 +38,9 @@ typedef struct psInternalParticleSystem
     float minLifetime; /**< Minimum lifetime in seconds for new particles. */
     float maxLifetime; /**< Maximum lifetime in seconds for new particles. */
 
+    float minAngularVelocity; /**< Minimum angular velocity in radians per second for new particles. */
+    float maxAngularVelocity; /**< Maximum angular velocity in radians per second for new particles. */
+
     float streamRate;        /**< Continuous emission rate in particles per second. */
     float streamAccumulator; /**< Fractional particle count accumulated since the last emit. */
 

--- a/src/ParticleSystem/ParticleSystemMessages.h
+++ b/src/ParticleSystem/ParticleSystemMessages.h
@@ -11,3 +11,5 @@ static const char MSG_INVALID_LIFETIME_RANGE[] = "min lifetime must not exceed m
 static const char MSG_INVALID_VELOCITY_RANGE[] = "min velocity must not exceed max velocity";
 static const char MSG_INVALID_ACCELERATION_RANGE[] =
     "min acceleration must not exceed max acceleration";
+static const char MSG_INVALID_ANGULAR_VELOCITY_RANGE[] =
+    "min angular velocity must not exceed max angular velocity";

--- a/tests/ParticleSystem.c
+++ b/tests/ParticleSystem.c
@@ -45,6 +45,8 @@ static const float MOCK_ACCELERATION_Y = 15.0f;
 static const float MOCK_LIFETIME = 0.5f;
 static const float SHORT_LIFETIME = MOCK_DT;
 
+static const float MOCK_ANGULAR_VELOCITY = 2.0f;
+
 static const float INNER_SPREAD_X = 1.0f;
 static const float INNER_SPREAD_Y = 2.0f;
 static const float OUTER_SPREAD_X = 3.0f;
@@ -204,6 +206,15 @@ void Test_psCreate_StartsWithZeroActiveParticles(void)
     tsPass(__func__);
 }
 
+void Test_psCreate_DefaultLifetimeIsOne(void)
+{
+    setup();
+    assert(ps->minLifetime == 1.0f);
+    assert(ps->maxLifetime == 1.0f);
+    teardown();
+    tsPass(__func__);
+}
+
 // Destroy —————————————————————————————————————————————————————————————————————————————————————————
 
 void Test_psDestroy_FreesSystem(void)
@@ -295,6 +306,17 @@ void Test_psReset_DoesNotResetSpread(void)
     assert(ps->emissionArea.innerSpreadY == INNER_SPREAD_Y);
     assert(ps->emissionArea.outerSpreadX == OUTER_SPREAD_X);
     assert(ps->emissionArea.outerSpreadY == OUTER_SPREAD_Y);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psReset_DoesNotResetAngularVelocityRange(void)
+{
+    setup();
+    psSetAngularVelocity(ps, MOCK_ANGULAR_VELOCITY, MOCK_ANGULAR_VELOCITY * 2);
+    assert(psReset(ps) == RES_OK);
+    assert(ps->minAngularVelocity == MOCK_ANGULAR_VELOCITY);
+    assert(ps->maxAngularVelocity == MOCK_ANGULAR_VELOCITY * 2);
     teardown();
     tsPass(__func__);
 }
@@ -453,6 +475,26 @@ void Test_psBurst_SetsAgeToZeroOnFreshSlot(void)
     setup();
     psBurst(ps, 1);
     assert(ps->particles[0].age == 0.0f);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psBurst_SetsAngleToZero(void)
+{
+    setup();
+    psSetAngularVelocity(ps, MOCK_ANGULAR_VELOCITY, MOCK_ANGULAR_VELOCITY);
+    psBurst(ps, 1);
+    assert(ps->particles[0].angle == 0.0f);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psBurst_SetsAngularVelocityFromRange(void)
+{
+    setup();
+    psSetAngularVelocity(ps, MOCK_ANGULAR_VELOCITY, MOCK_ANGULAR_VELOCITY);
+    psBurst(ps, 1);
+    assert(ps->particles[0].angularVelocity == MOCK_ANGULAR_VELOCITY);
     teardown();
     tsPass(__func__);
 }
@@ -832,6 +874,51 @@ void Test_psUpdate_AccumulatorContinuesWhenPoolExhausted(void)
     tsPass(__func__);
 }
 
+void Test_psUpdate_ParticleWithDefaultLifetimeSurvivesOneTick(void)
+{
+    setup();
+    psBurst(ps, 1);
+    psUpdate(ps, MOCK_DT);
+    assert(ps->activeParticles == 1);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psUpdate_ParticleWithInfiniteLifetimeNeverDies(void)
+{
+    setup();
+    psSetLifetime(ps, INFINITY, INFINITY);
+    psBurst(ps, 1);
+    for (int i = 0; i < STRESS_ITERATIONS; i++)
+        psUpdate(ps, MOCK_DT);
+    assert(ps->activeParticles == 1);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psUpdate_AdvancesAngleByAngularVelocity(void)
+{
+    setup();
+    psSetLifetime(ps, MOCK_LIFETIME, MOCK_LIFETIME);
+    psSetAngularVelocity(ps, MOCK_ANGULAR_VELOCITY, MOCK_ANGULAR_VELOCITY);
+    psBurst(ps, 1);
+    psUpdate(ps, MOCK_DT);
+    assert(ps->particles[0].angle == MOCK_ANGULAR_VELOCITY * MOCK_DT);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psUpdate_DefaultAngularVelocityKeepsAngleAtZero(void)
+{
+    setup();
+    psSetLifetime(ps, MOCK_LIFETIME, MOCK_LIFETIME);
+    psBurst(ps, 1);
+    psUpdate(ps, MOCK_DT);
+    assert(ps->particles[0].angle == 0.0f);
+    teardown();
+    tsPass(__func__);
+}
+
 void Test_psUpdate_AccumulatorDecrementsOnlyByActualSpawns(void)
 {
     setup();
@@ -1010,6 +1097,18 @@ void Test_psSetLifetime_AffectsSpawnedParticles(void)
     psSetLifetime(ps, MOCK_LIFETIME, MOCK_LIFETIME);
     psBurst(ps, 1);
     assert(ps->particles[0].lifetime == MOCK_LIFETIME);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psSetLifetime_AllowsInfinity(void)
+{
+    setup();
+    assert(psSetLifetime(ps, INFINITY, INFINITY) == RES_OK);
+    psBurst(ps, 1);
+    for (int i = 0; i < STRESS_ITERATIONS; i++)
+        psUpdate(ps, MOCK_DT);
+    assert(ps->activeParticles == 1);
     teardown();
     tsPass(__func__);
 }
@@ -1254,6 +1353,60 @@ void Test_psSetOrigin_UpdatesOrigin(void)
 void Test_psSetOrigin_IsNullSafe(void)
 {
     assert(psSetOrigin(nullptr, ORIGIN_X, ORIGIN_Y) == RES_NULL_ARG);
+    tsPass(__func__);
+}
+
+void Test_psSetAngularVelocity_SetsRange(void)
+{
+    setup();
+    assert(psSetAngularVelocity(ps, MOCK_ANGULAR_VELOCITY, MOCK_ANGULAR_VELOCITY * 2) == RES_OK);
+    assert(ps->minAngularVelocity == MOCK_ANGULAR_VELOCITY);
+    assert(ps->maxAngularVelocity == MOCK_ANGULAR_VELOCITY * 2);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psSetAngularVelocity_IsNullSafe(void)
+{
+    assert(psSetAngularVelocity(nullptr, MOCK_ANGULAR_VELOCITY, MOCK_ANGULAR_VELOCITY) ==
+        RES_NULL_ARG);
+    tsPass(__func__);
+}
+
+void Test_psSetAngularVelocity_RejectsMinGreaterThanMax(void)
+{
+    setup();
+    assert(psSetAngularVelocity(ps, MOCK_ANGULAR_VELOCITY * 2, MOCK_ANGULAR_VELOCITY) ==
+        RES_INVALID_ARG);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psSetAngularVelocity_AllowsMinEqualToMax(void)
+{
+    setup();
+    assert(psSetAngularVelocity(ps, 0.0f, 0.0f) == RES_OK);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psSetAngularVelocity_DefaultIsZero(void)
+{
+    setup();
+    assert(ps->minAngularVelocity == 0.0f);
+    assert(ps->maxAngularVelocity == 0.0f);
+    teardown();
+    tsPass(__func__);
+}
+
+void Test_psSetAngularVelocity_AffectsSpawnedParticles(void)
+{
+    setup();
+    psSetLifetime(ps, MOCK_LIFETIME, MOCK_LIFETIME);
+    psSetAngularVelocity(ps, MOCK_ANGULAR_VELOCITY, MOCK_ANGULAR_VELOCITY);
+    psBurst(ps, 1);
+    assert(ps->particles[0].angularVelocity == MOCK_ANGULAR_VELOCITY);
+    teardown();
     tsPass(__func__);
 }
 
@@ -1630,6 +1783,7 @@ int main(void)
     Test_psCreate_ReturnsNullWhenCallocFails();
     Test_psCreate_StoresOrigin();
     Test_psCreate_StartsWithZeroActiveParticles();
+    Test_psCreate_DefaultLifetimeIsOne();
 
     puts("\nDESTROY TESTING");
     Test_psDestroy_FreesSystem();
@@ -1643,6 +1797,7 @@ int main(void)
     Test_psReset_DoesNotResetVelocityRange();
     Test_psReset_DoesNotResetEmissionShape();
     Test_psReset_DoesNotResetSpread();
+    Test_psReset_DoesNotResetAngularVelocityRange();
     Test_psReset_IsNullSafe();
 
     puts("\nBURST TESTING");
@@ -1659,6 +1814,8 @@ int main(void)
     Test_psBurst_SpawnsParticlesOutsideInnerRectBounds();
     Test_psBurst_SpawnsParticlesOutsideInnerEllipseBounds();
     Test_psBurst_SetsAgeToZeroOnFreshSlot();
+    Test_psBurst_SetsAngleToZero();
+    Test_psBurst_SetsAngularVelocityFromRange();
     Test_psBurst_ResetsAgeWhenSlotIsReused();
     Test_psBurst_ReusedParticleDoesNotExpireImmediately();
 
@@ -1700,6 +1857,10 @@ int main(void)
     Test_psUpdate_AdvancesParticleAge();
     Test_psUpdate_MovesParticlesWithVelocity();
     Test_psUpdate_AppliesAccelerationToVelocity();
+    Test_psUpdate_ParticleWithDefaultLifetimeSurvivesOneTick();
+    Test_psUpdate_ParticleWithInfiniteLifetimeNeverDies();
+    Test_psUpdate_AdvancesAngleByAngularVelocity();
+    Test_psUpdate_DefaultAngularVelocityKeepsAngleAtZero();
     Test_psUpdate_KillsParticleWhenLifetimeExpires();
     Test_psUpdate_KillsMultipleExpiredParticlesInSameFrame();
     Test_psUpdate_KillsNonContiguousParticlesCorrectly();
@@ -1725,6 +1886,7 @@ int main(void)
     Test_psSetLifetime_IsNullSafe();
     Test_psSetLifetime_RejectsMinGreaterThanMax();
     Test_psSetLifetime_AffectsSpawnedParticles();
+    Test_psSetLifetime_AllowsInfinity();
     puts("• psSetVelocity");
     Test_psSetVelocity_SetsRange();
     Test_psSetVelocity_IsNullSafe();
@@ -1755,6 +1917,13 @@ int main(void)
     Test_psSetOrigin_AffectsSpawnedParticles();
     Test_psSetOrigin_UpdatesOrigin();
     Test_psSetOrigin_IsNullSafe();
+    puts("• psSetAngularVelocity");
+    Test_psSetAngularVelocity_SetsRange();
+    Test_psSetAngularVelocity_IsNullSafe();
+    Test_psSetAngularVelocity_RejectsMinGreaterThanMax();
+    Test_psSetAngularVelocity_AllowsMinEqualToMax();
+    Test_psSetAngularVelocity_DefaultIsZero();
+    Test_psSetAngularVelocity_AffectsSpawnedParticles();
 
     puts("\nINFLUENCE TESTING");
     Test_psSetInfluence_SetsCallback();


### PR DESCRIPTION
- Add float angle and float angularVelocity fields to Particle; angle is initialized to 0 on emission and advanced by angularVelocity * dt each update
- Add psSetAngularVelocity(ps, min, max) with the same validation and range sampling pattern as other movement setters; defaults to 0.0f (no rotation)
- Initialize default minLifetime/maxLifetime to 1.0f in psCreate instead of 0.0f, so particles emitted without an explicit psSetLifetime call survive rather than dying on the first update
- Document INFINITY as the sentinel for immortal particles in psSetLifetime
- Add 16 new tests covering all new behaviour; update API and README docs